### PR TITLE
docs: add bilingual server deployment guide pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MorseLink 由 **BI4MOL** 开发，是一款专业级 CW（摩尔斯电码）训�
 
 ### 🛠 服务器部署指南
 
-[点击查看服务器搭建方式](https://github.com/TateLuo/MorseLink/wiki/%E5%A6%82%E4%BD%95%E6%90%AD%E5%BB%BA%E6%9C%8D%E5%8A%A1%E5%99%A8)
+[中文：查看服务器搭建方式](./docs/wiki/如何搭建服务器_zh_CN.md)<br>[English: Server Deployment Guide](./docs/wiki/How-to-Deploy-a-MorseLink-Server_en.md)
 
 ---
 
@@ -63,7 +63,7 @@ The system integrates **structured stage-based training** with **real-time MQTT-
 
 ### 🛠 Server Deployment Guide
 
-[Learn How to Deploy Your Own Server](https://github.com/TateLuo/MorseLink/wiki/%E5%A6%82%E4%BD%95%E6%90%AD%E5%BB%BA%E6%9C%8D%E5%8A%A1%E5%99%A8)
+[Chinese: Server Deployment Guide](./docs/wiki/如何搭建服务器_zh_CN.md)<br>[English: How to Deploy a MorseLink Server](./docs/wiki/How-to-Deploy-a-MorseLink-Server_en.md)
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,4 +1,4 @@
-[中文简介请点击此处](/README_zh_CN.md) | [中文使用手册请点击此处](https://github.com/TateLuo/MorseLink/wiki/MorseLink%E4%BD%BF%E7%94%A8%E6%89%8B%E5%86%8C_zh_CN) | [Click here for the user manual](https://github.com/TateLuo/MorseLink/wiki/MorseLink-User-Manual_en) | [下载&Download](https://github.com/TateLuo/MorseLink/releases)
+[中文简介请点击此处](/README.md) | [中文使用手册请点击此处](https://github.com/TateLuo/MorseLink/wiki/MorseLink%E4%BD%BF%E7%94%A8%E6%89%8B%E5%86%8C_zh_CN) | [Click here for the user manual](https://github.com/TateLuo/MorseLink/wiki/MorseLink-User-Manual_en) | [中文服务器搭建](./docs/wiki/如何搭建服务器_zh_CN.md) | [Server Deployment (EN)](./docs/wiki/How-to-Deploy-a-MorseLink-Server_en.md) | [下载&Download](https://github.com/TateLuo/MorseLink/releases)
 
 *****Will Not update the English version, and removed the English language from MorseLink.*****
 

--- a/docs/wiki/How-to-Deploy-a-MorseLink-Server_en.md
+++ b/docs/wiki/How-to-Deploy-a-MorseLink-Server_en.md
@@ -1,0 +1,91 @@
+# How to Deploy a MorseLink Server (English)
+
+> This guide explains how to quickly deploy an MQTT server for MorseLink clients.
+
+## 1. Deployment Overview
+
+MorseLink relies on MQTT for real-time communication. You need:
+
+- A cloud server (Linux, Ubuntu 22.04 recommended)
+- A public IP or domain name
+- An MQTT broker (EMQX recommended)
+
+---
+
+## 2. Install EMQX with Docker (Recommended)
+
+```bash
+docker run -d \
+  --name emqx \
+  -p 1883:1883 \
+  -p 8883:8883 \
+  -p 18083:18083 \
+  --restart unless-stopped \
+  emqx/emqx:latest
+```
+
+Port usage:
+
+- `1883`: MQTT plaintext (`mqtt`)
+- `8883`: MQTT over TLS (`mqtts`)
+- `18083`: EMQX dashboard/admin console
+
+---
+
+## 3. Firewall & Security Group Rules
+
+Open at least these TCP ports:
+
+- `1883` (required)
+- `8883` (recommended for TLS)
+- `18083` (admin only; ideally restricted by IP allowlist)
+
+---
+
+## 4. Configure Server Endpoint in MorseLink
+
+Relevant client-side settings:
+
+- `server/scheme`: `mqtt` or `mqtts`
+- `server/host`: your server IP or domain
+- `server/active_port`: 1883 or 8883
+- `server/customized_endpoints`: e.g. `mqtt://example.com:1883`
+
+Examples:
+
+- Plain MQTT: `mqtt://your-server-ip:1883`
+- TLS MQTT: `mqtts://your-domain:8883`
+
+---
+
+## 5. Recommended Production Practices
+
+- Prefer `mqtts` (TLS)
+- Enable authentication (username/password)
+- Keep EMQX up to date
+- Restrict admin port `18083` by IP
+- Set up monitoring and log backups
+
+---
+
+## 6. Quick Troubleshooting
+
+### Cannot connect to server
+
+1. Verify firewall/security group rules.
+2. Ensure EMQX container is running: `docker ps`
+3. Check endpoint fields in client (`scheme`, `host`, `port`).
+
+### Connected but cannot communicate
+
+1. Confirm channel/topic alignment.
+2. Check credentials if authentication is enabled.
+3. Inspect connection logs in EMQX dashboard.
+
+---
+
+## 7. Chinese Version
+
+For the Chinese version, see:
+
+- [如何搭建 MorseLink 服务器（中文版）](./如何搭建服务器_zh_CN.md)

--- a/docs/wiki/如何搭建服务器_zh_CN.md
+++ b/docs/wiki/如何搭建服务器_zh_CN.md
@@ -1,0 +1,91 @@
+# 如何搭建 MorseLink 服务器（中文版）
+
+> 本文档用于指导你快速部署一个可用于 MorseLink 客户端连接的 MQTT 服务器。
+
+## 1. 部署方式概览
+
+MorseLink 客户端本质上通过 MQTT 协议进行在线收发，因此你需要准备：
+
+- 一台云服务器（Linux 推荐 Ubuntu 22.04）
+- 一个可访问的公网 IP 或域名
+- MQTT Broker（推荐 EMQX）
+
+---
+
+## 2. 使用 Docker 安装 EMQX（推荐）
+
+```bash
+docker run -d \
+  --name emqx \
+  -p 1883:1883 \
+  -p 8883:8883 \
+  -p 18083:18083 \
+  --restart unless-stopped \
+  emqx/emqx:latest
+```
+
+端口说明：
+
+- `1883`：MQTT 明文连接（mqtt）
+- `8883`：MQTT TLS 连接（mqtts）
+- `18083`：EMQX 控制台管理页面
+
+---
+
+## 3. 防火墙与安全组
+
+请确保服务器放行以下端口：
+
+- TCP `1883`（至少）
+- TCP `8883`（建议，启用 TLS 时需要）
+- TCP `18083`（仅管理员使用，可限制为白名单 IP）
+
+---
+
+## 4. 在客户端中配置服务器地址
+
+MorseLink 客户端对应配置项：
+
+- `server/scheme`：`mqtt` 或 `mqtts`
+- `server/host`：你的服务器 IP 或域名
+- `server/active_port`：1883 或 8883
+- `server/customized_endpoints`：例如 `mqtt://example.com:1883`
+
+示例：
+
+- 明文连接：`mqtt://your-server-ip:1883`
+- TLS 连接：`mqtts://your-domain:8883`
+
+---
+
+## 5. 建议的生产环境配置
+
+- 优先使用 `mqtts`（TLS）
+- 启用认证（用户名/密码）
+- 定期更新 EMQX 版本
+- 对管理端口 `18083` 做 IP 白名单
+- 配置监控与日志备份
+
+---
+
+## 6. 快速排查
+
+### 无法连接服务器
+
+1. 检查端口是否开放（安全组/防火墙）
+2. 检查 EMQX 容器是否运行：`docker ps`
+3. 检查客户端地址是否填写正确（scheme、host、port）
+
+### 能连接但无法通信
+
+1. 确认频道/主题一致
+2. 检查是否开启了认证且凭据错误
+3. 查看 EMQX 控制台连接日志
+
+---
+
+## 7. 英文版文档
+
+如果你需要英文版，请查看：
+
+- [How to Deploy a MorseLink Server (English)](./How-to-Deploy-a-MorseLink-Server_en.md)


### PR DESCRIPTION
### Motivation

- Provide a matching English version of the existing Chinese server deployment wiki so the repository has bilingual server setup docs similar to the user manual layout.
- Replace external wiki links in the README with local, version-controlled pages for easier maintenance and offline access.

### Description

- Added `docs/wiki/如何搭建服务器_zh_CN.md` containing the Chinese server deployment guide.
- Added `docs/wiki/How-to-Deploy-a-MorseLink-Server_en.md` as the corresponding English guide.
- Updated `README.md` to link the Chinese and English deployment pages in both Chinese and English sections via local paths.
- Updated `README_en.md` quick-links row to include direct links to both `docs/wiki/如何搭建服务器_zh_CN.md` and `docs/wiki/How-to-Deploy-a-MorseLink-Server_en.md`.

### Testing

- Ran `git diff --check` to validate whitespace and diff warnings, which passed after fixes.
- Verified working tree state with `git status --short` to confirm modified and new files are staged.
- Confirmed commit presence with `git rev-parse --abbrev-ref HEAD && git log -1 --oneline`, showing the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc19cf6f48331b0b687423c25a8fe)